### PR TITLE
Use MaxInt32 instead of MaxUInt32 for comparison with len(). Fix for Raspberry Pi

### DIFF
--- a/lencode.go
+++ b/lencode.go
@@ -78,7 +78,7 @@ func (e *Encoder) Encode(msg []byte) error {
 		return e.err
 	}
 
-	if len(msg) > math.MaxUint32 {
+	if len(msg) > math.MaxInt32 {
 		e.err = errors.New("Message too long to encode length in 4 bytes")
 		return e.err
 	}


### PR DESCRIPTION
Hi.

First of all thanks for this module, it's very nice and easy to use.

I was trying to compile my program that uses this module into raspberry pi and ran into a compile error. It looks like `len` in go returns an `int` instead of a `uint`, and when you try to compile for raspberry pi (and I'm assuming other 32-bit machines), it doesn't work because `MaxUInt32` doesn't fit inside of an `int32`. This change fixed it for me.